### PR TITLE
initialize method for inputs

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -55,3 +55,21 @@ addDeps <- function(x) {
   )
   appendDependencies(x, f7Deps)
 }
+
+#' @importFrom utils packageVersion
+#' @importFrom htmltools htmlDependency
+f7InputsDeps <- function() {
+  htmltools::htmlDependency(
+    name = "framework7-bindings",
+    version = as.character(packageVersion("shinyF7")),
+    src = c(
+      file = system.file("framework7-4.3.1/input-bindings", package = "shinyF7"),
+      href = "framework7-4.3.1/input-bindings"
+    ),
+    package = "shinyF7",
+    script = c("sliderInputBinding.js",
+               "stepperInputBinding.js",
+               "toggleInputBinding.js")
+  )
+}
+

--- a/R/f7-inputs.R
+++ b/R/f7-inputs.R
@@ -413,11 +413,7 @@ f7Slider <- function(inputId, label, min, max, value,
 
   # custom input binding
   shiny::tagList(
-    shiny::singleton(
-      shiny::tags$head(
-        shiny::includeScript(path = system.file("framework7-4.3.1/input-bindings/sliderInputBinding.js", package = "shinyF7"))
-      )
-    ),
+    f7InputsDeps(),
     # HTML skeleton
     shiny::br(),
     shiny::tags$div(class = "block-title", label),
@@ -522,11 +518,7 @@ f7Stepper <- function(inputId, label, min, max, value, step = 1,
   if (!is.null(color)) stepperCl <- paste0(stepperCl, " color-", color)
 
   shiny::tagList(
-    shiny::singleton(
-      shiny::tags$head(
-        shiny::includeScript(path = system.file("framework7-4.3.1/input-bindings/stepperInputBinding.js", package = "shinyF7"))
-      )
-    ),
+    f7InputsDeps(),
     # stepper tag
     shiny::tags$small(label),
     shiny::tags$div(
@@ -604,11 +596,7 @@ f7Toggle <- function(inputId, label, checked = FALSE, color = NULL) {
   shiny::tagList(
 
     # input binding
-    shiny::singleton(
-      shiny::tags$head(
-        shiny::includeScript(path = system.file("framework7-4.3.1/input-bindings/toggleInputBinding.js", package = "shinyF7"))
-      )
-    ),
+    f7InputsDeps(),
     # toggle tag
     shiny::tags$span(label),
     shiny::tags$label(

--- a/R/f7-inputs.R
+++ b/R/f7-inputs.R
@@ -418,20 +418,6 @@ f7Slider <- function(inputId, label, min, max, value,
         shiny::includeScript(path = system.file("framework7-4.3.1/input-bindings/sliderInputBinding.js", package = "shinyF7"))
       )
     ),
-    # slider initialization
-    shiny::singleton(
-      shiny::tags$head(
-        shiny::tags$script(
-          paste0(
-            "// init the slider component
-                $(function() {
-                  var range = app.range.create({ el: '#", inputId,"' });
-                });
-              "
-          )
-        )
-      )
-    ),
     # HTML skeleton
     shiny::br(),
     shiny::tags$div(class = "block-title", label),
@@ -541,22 +527,6 @@ f7Stepper <- function(inputId, label, min, max, value, step = 1,
         shiny::includeScript(path = system.file("framework7-4.3.1/input-bindings/stepperInputBinding.js", package = "shinyF7"))
       )
     ),
-    # javascript initialization
-    shiny::singleton(
-      shiny::tags$head(
-        shiny::tags$script(
-          paste0(
-            "$(function(){
-              var stepper = app.stepper.create({
-                el: '#", inputId,"'
-              });
-             });
-            "
-          )
-        )
-      )
-    ),
-
     # stepper tag
     shiny::tags$small(label),
     shiny::tags$div(
@@ -637,21 +607,6 @@ f7Toggle <- function(inputId, label, checked = FALSE, color = NULL) {
     shiny::singleton(
       shiny::tags$head(
         shiny::includeScript(path = system.file("framework7-4.3.1/input-bindings/toggleInputBinding.js", package = "shinyF7"))
-      )
-    ),
-    # javascript initialization
-    shiny::singleton(
-      shiny::tags$head(
-        shiny::tags$script(
-          paste0(
-            "$(function(){
-              var toggle = app.toggle.create({
-                el: '#", inputId,"'
-              });
-             });
-            "
-          )
-        )
       )
     ),
     # toggle tag

--- a/inst/framework7-4.3.1/input-bindings/sliderInputBinding.js
+++ b/inst/framework7-4.3.1/input-bindings/sliderInputBinding.js
@@ -2,6 +2,11 @@
 var f7SliderBinding = new Shiny.InputBinding();
 
 $.extend(f7SliderBinding, {
+
+  initialize: function(el) {
+    app.range.create({el: el});
+  },
+
   find: function(scope) {
     return $(scope).find(".range-slider");
   },

--- a/inst/framework7-4.3.1/input-bindings/stepperInputBinding.js
+++ b/inst/framework7-4.3.1/input-bindings/stepperInputBinding.js
@@ -2,6 +2,11 @@
 var f7StepperBinding = new Shiny.InputBinding();
 
 $.extend(f7StepperBinding, {
+
+  initialize: function(el) {
+    app.stepper.create({el: el});
+  },
+
   find: function(scope) {
     return $(scope).find(".stepper");
   },

--- a/inst/framework7-4.3.1/input-bindings/toggleInputBinding.js
+++ b/inst/framework7-4.3.1/input-bindings/toggleInputBinding.js
@@ -2,6 +2,11 @@
 var f7ToggleBinding = new Shiny.InputBinding();
 
 $.extend(f7ToggleBinding, {
+
+  initialize: function(el) {
+    app.toggle.create({el: el});
+  },
+
   find: function(scope) {
     return $(scope).find(".toggle");
   },


### PR DESCRIPTION
Hello David,

I added an initialize method in Shiny's bindings for input requiring JavaScript initialization. This works fine in `renderUI` now.

Can I modify the way you include dependencies ? Not a big fan of `includeScript`, it will be nicer with an `htmlDependency` i think. I can add that to the PR.

